### PR TITLE
Update browser support table due to partial support in Safari.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Unfortunately, the [Web Speech API](https://dvcs.w3.org/hg/speech-api/raw-file/t
 
 ![IE](https://cloud.githubusercontent.com/assets/398893/3528325/20373e76-078e-11e4-8e3a-1cb86cf506f0.png) | ![Chrome](https://cloud.githubusercontent.com/assets/398893/3528328/23bc7bc4-078e-11e4-8752-ba2809bf5cce.png) | ![Firefox](https://cloud.githubusercontent.com/assets/398893/3528329/26283ab0-078e-11e4-84d4-db2cf1009953.png) | ![Opera](https://cloud.githubusercontent.com/assets/398893/3528330/27ec9fa8-078e-11e4-95cb-709fd11dac16.png) | ![Safari](https://cloud.githubusercontent.com/assets/398893/3528331/29df8618-078e-11e4-8e3e-ed8ac738693f.png)
 --- | --- | --- | --- | --- |
-None ✘ | Latest ✔ | None ✘ | None ✘ | Latest ✔ |
+None ✘ | Latest ✔ | None ✘ | None ✘ | Latest (&lt;voice-player&gt; only) ✔ |
 
 ## Development
 


### PR DESCRIPTION
Partial support in Safari refers to only Speech Synthesis supported.